### PR TITLE
using transient data to set uri

### DIFF
--- a/hybrid/offchain.go
+++ b/hybrid/offchain.go
@@ -101,7 +101,18 @@ func (s *RoamingSmartContract) getRESTConfig(ctx contractapi.TransactionContextI
 }
 
 // SetRESTConfig stores the rest endpoint config
-func (s *RoamingSmartContract) SetRESTConfig(ctx contractapi.TransactionContextInterface, uri string) error {
+func (s *RoamingSmartContract) SetRESTConfig(ctx contractapi.TransactionContextInterface) error {
+	// uri is stored in transient map to hide it from other organizations
+	transMap, err := ctx.GetStub().GetTransient()
+	if err != nil {
+		return fmt.Errorf("Error getting transient: " + err.Error())
+	}
+
+	uri, ok := transMap["uri"]
+	if !ok {
+		return fmt.Errorf("uri not found in the transient map")
+	}
+
 	// fetch name of the senders implicit collection
 	implicitCollection, err := getImplicitCollection(ctx)
 	if err != nil {
@@ -109,7 +120,7 @@ func (s *RoamingSmartContract) SetRESTConfig(ctx contractapi.TransactionContextI
 	}
 
 	// store data in implicit collection
-	return ctx.GetStub().PutPrivateData(implicitCollection, "REST_URI", []byte(uri))
+	return ctx.GetStub().PutPrivateData(implicitCollection, "REST_URI", uri)
 }
 
 // GetEvaluateTransactions returns functions of RoamingSmartContract to be tagged as evaluate (=query)

--- a/hybrid/offchain_test.go
+++ b/hybrid/offchain_test.go
@@ -118,17 +118,28 @@ func TestExchangeAndSigning(t *testing.T) {
 	// a test document:
 	documentBase64 := base64.StdEncoding.EncodeToString([]byte(`data!1234...`))
 
+	// Prepare transient data map
+	var transient map[string][]byte
+	transient = make(map[string][]byte)
+
 	// ORG1 as "sender"
 	txContextORG1, err := prepareTransactionContext(mockStub, ORG1.Name, ORG1.Certificate)
 	require.NoError(t, err)
+
 	// ORG2 as "receiver" and later signer
 	txContextORG2, err := prepareTransactionContext(mockStub, ORG2.Name, ORG2.Certificate)
 	require.NoError(t, err)
 
-	// configure rest endpoints
-	err = contractORG1.SetRESTConfig(txContextORG1, "http://localhost:3001/documents")
+	// Set transient data for Org1
+	transient["uri"] = []byte("http://localhost:3001/documents")
+	mockStub.TransientMap = transient
+	err = contractORG1.SetRESTConfig(txContextORG1)
 	require.NoError(t, err)
-	err = contractORG2.SetRESTConfig(txContextORG2, "http://localhost:3002/documents")
+
+	// Set transient data for Org2
+	transient["uri"] = []byte("http://localhost:3002/documents")
+	mockStub.TransientMap = transient
+	err = contractORG2.SetRESTConfig(txContextORG2)
 	require.NoError(t, err)
 
 	// QUERY store document on ORG1 (local)


### PR DESCRIPTION
Using a plain parameter leaks the uri to all participants. Using a transient map hides the passed parameters before storing them in the implicit collection.