### PR TITLE
Expose verifyreferencepayloadlink and add Tests

### DIFF
--- a/hybrid/contract/roaming.go
+++ b/hybrid/contract/roaming.go
@@ -190,6 +190,7 @@ func (s *RoamingSmartContract) GetEvaluateTransactions() []string {
 		"StorePrivateDocument",
 		"FetchPrivateDocument",
 		"FetchPrivateDocumentReferenceIDs",
+		"VerifyReferencePayloadLink",
 	}
 }
 
@@ -251,7 +252,7 @@ func (s *RoamingSmartContract) CreateStorageKey(targetMSPID string, referenceID 
 	return storageKey, nil
 }
 
-func (s *RoamingSmartContract) verifyReferencePayloadLink(ctx contractapi.TransactionContextInterface, creatorMSPID string, referenceID string, payloadHash string) (bool, error) {
+func (s *RoamingSmartContract) VerifyReferencePayloadLink(ctx contractapi.TransactionContextInterface, creatorMSPID string, referenceID string, payloadHash string) (bool, error) {
 	log.Debugf("%s(%s, %s, %s)", util.FunctionName(1), creatorMSPID, referenceID, payloadHash)
 
 	// ACL restricted to local queries only
@@ -834,7 +835,7 @@ func (s *RoamingSmartContract) FetchPrivateDocument(ctx contractapi.TransactionC
 	}
 
 	// check if this document matches to what was published on the ledger
-	referencePayloadLinkValid, err := s.verifyReferencePayloadLink(ctx, data.FromMSP, referenceID, expectedPayloadHash)
+	referencePayloadLinkValid, err := s.VerifyReferencePayloadLink(ctx, data.FromMSP, referenceID, expectedPayloadHash)
 	if err != nil {
 		// it is safe to forward local errors
 		return "", err

--- a/hybrid/offchain_test.go
+++ b/hybrid/offchain_test.go
@@ -218,6 +218,11 @@ func TestStoreDocumentPayloadLink(t *testing.T) {
 	err = ep1.InvokePublishReferencePayloadLink(ep1, referenceKey, referenceValue)
 	require.NoError(t, err)
 
+	// also check the verify function says true as well:
+	manualTest, err := ep1.VerifyReferencePayloadLink(ep1, "ORG1", referenceID, ExampleDocument.PayloadHash)
+	require.NoError(t, err)
+	require.True(t, manualTest)
+
 	// readback should now work
 	dataJSON, err := ep1.FetchPrivateDocument(ep1, referenceID)
 	require.NoError(t, err)
@@ -263,6 +268,11 @@ func TestStoreBadDocumentPayloadLink(t *testing.T) {
 	referenceValue := referencePayloadLink[1]
 	err = ep1.InvokePublishReferencePayloadLink(ep1, referenceKey, referenceValue)
 	require.NoError(t, err)
+
+	// also check the verify function says false as well:
+	manualTest, err := ep1.VerifyReferencePayloadLink(ep1, "ORG1", referenceID, ExampleDocument.PayloadHash)
+	require.NoError(t, err)
+	require.False(t, manualTest)
 
 	// readback should detect this bad payloadlink
 	_, err = ep1.FetchPrivateDocument(ep1, referenceID)

--- a/hybrid/test/endpoint/helpers.go
+++ b/hybrid/test/endpoint/helpers.go
@@ -132,6 +132,12 @@ func (local Endpoint) InvokeStoreSignature(caller Endpoint, key string, signatur
 	return err
 }
 
+func (local Endpoint) VerifyReferencePayloadLink(caller Endpoint, creatorMSPID string, referenceID string, payloadHash string) (bool, error) {
+	log.Debugf("%s()", util.FunctionName(1))
+	os.Setenv("CORE_PEER_LOCALMSPID", local.org.Name)
+	return local.contract.VerifyReferencePayloadLink(caller.txContext, creatorMSPID, referenceID, payloadHash)
+}
+
 func CreateEndpoints(t *testing.T) (Endpoint, Endpoint) {
 	// set loglevel
 	//log.SetLevel(log.InfoLevel)


### PR DESCRIPTION
This depends/builds upon #32 

This PR will expose the VerifyReferencePayloadLink function and adds test cases to the testing framework.