### PR TITLE
fix #45 by using unreachable port instead of IP for ocdb test

### DIFF
--- a/hybrid/offchain_test.go
+++ b/hybrid/offchain_test.go
@@ -89,7 +89,7 @@ func TestOffchainDBConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// break config:
-	url := "http://0.1.2.3/nodb"
+	url := "http://localhost:0/nodb"
 	err = ep1.SetOffchainDBConfig(url)
 	// setting this will fail (connection refused)
 	require.Error(t, err)


### PR DESCRIPTION
fixes https://github.com/GSMA-CPAS/BWRP-chaincode/issues/45
